### PR TITLE
Upgrade to `torch==2.2.0`

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,7 +49,7 @@ jobs:
       matrix:
           os: ['ubuntu-20.04']
           python-version: ['3.8', '3.9', '3.10', '3.11']
-          pytorch-version: ['2.1.2']  # Must be the most recent version that meets requirements.txt.
+          pytorch-version: ['2.2.0']  # Must be the most recent version that meets requirements.txt.
           cuda-version: ['11.8', '12.1']
 
     steps:

--- a/Dockerfile.rocm
+++ b/Dockerfile.rocm
@@ -65,7 +65,7 @@ RUN mkdir libs \
 COPY ./ /app/vllm
 
 RUN python3 -m pip install --upgrade pip
-RUN python3 -m pip install xformers==0.0.23 --no-deps
+RUN python3 -m pip install xformers==0.0.24 --no-deps
 
 # Error related to odd state for numpy 1.20.3 where there is no METADATA etc, but an extra LICENSES_bundled.txt.
 # Manually removed it so that later steps of numpy upgrade can continue

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "ninja",
     "packaging",
     "setuptools >= 49.4.0",
-    "torch == 2.1.2",
+    "torch == 2.2.0",
     "wheel",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements-build.txt
+++ b/requirements-build.txt
@@ -2,5 +2,5 @@
 ninja
 packaging
 setuptools>=49.4.0
-torch==2.1.2
+torch==2.2.0
 wheel

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,6 +15,7 @@ pytest-forked
 pytest-asyncio
 httpx
 einops # required for MPT
+wheel # required for flash_attn
 flash_attn # required for HuggingFace's llama implementation
 openai
 requests

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,9 +3,9 @@ psutil
 ray >= 2.9
 sentencepiece  # Required for LLaMA tokenizer.
 numpy
-torch == 2.1.2
+torch == 2.2.0
 transformers >= 4.37.0 # Required for Qwen2
-xformers == 0.0.23.post1  # Required for CUDA 12.1.
+xformers == 0.0.24  # Required for CUDA 12.1.
 fastapi
 uvicorn[standard]
 pydantic >= 2.0  # Required for OpenAI server.


### PR DESCRIPTION
- `torch==2.1.1` -> `torch==2.2.0`
- `xformers==0.0.23.post1` -> `xformers==0.0.24`
- ROCM not updated because no `torch==2.2.0` containers have been published yet