### PR TITLE
Allow model to be served under multiple names

### DIFF
--- a/vllm/entrypoints/openai/api_server.py
+++ b/vllm/entrypoints/openai/api_server.py
@@ -75,12 +75,17 @@ def parse_args():
         help=
         "If provided, the server will require this key to be presented in the header."
     )
-    parser.add_argument("--served-model-name",
-                        type=str,
-                        default=None,
-                        help="The model name used in the API. If not "
-                        "specified, the model name will be the same as "
-                        "the huggingface name.")
+    parser.add_argument(
+        "--served-model-name",
+        nargs="+",
+        type=str,
+        default=None,
+        help="The model name(s) used in the API. If multiple "
+        "names are provided, the server will respond to any of "
+        "the provided names. The model name in the model field "
+        "of a response will be the first name in this list. If "
+        "not specified, the model name will be the same as the "
+        "huggingface name.")
     parser.add_argument("--chat-template",
                         type=str,
                         default=None,
@@ -209,16 +214,17 @@ if __name__ == "__main__":
     logger.info(f"args: {args}")
 
     if args.served_model_name is not None:
-        served_model = args.served_model_name
+        served_model_names = args.served_model_name
     else:
-        served_model = args.model
+        served_model_names = [args.model]
 
     engine_args = AsyncEngineArgs.from_cli_args(args)
     engine = AsyncLLMEngine.from_engine_args(engine_args)
-    openai_serving_chat = OpenAIServingChat(engine, served_model,
+    openai_serving_chat = OpenAIServingChat(engine, served_model_names,
                                             args.response_role,
                                             args.chat_template)
-    openai_serving_completion = OpenAIServingCompletion(engine, served_model)
+    openai_serving_completion = OpenAIServingCompletion(
+        engine, served_model_names)
 
     # Register labels for metrics
     add_global_metrics_labels(model_name=engine_args.model)

--- a/vllm/entrypoints/openai/serving_engine.py
+++ b/vllm/entrypoints/openai/serving_engine.py
@@ -15,9 +15,9 @@ logger = init_logger(__name__)
 
 class OpenAIServing:
 
-    def __init__(self, engine: AsyncLLMEngine, served_model: str):
+    def __init__(self, engine: AsyncLLMEngine, served_model_names: List[str]):
         self.engine = engine
-        self.served_model = served_model
+        self.served_model_names = served_model_names
 
         self.max_model_len = 0
         self.tokenizer = None
@@ -46,9 +46,10 @@ class OpenAIServing:
     async def show_available_models(self) -> ModelList:
         """Show available models. Right now we only have one model."""
         model_cards = [
-            ModelCard(id=self.served_model,
-                      root=self.served_model,
+            ModelCard(id=served_model_name,
+                      root=served_model_name,
                       permission=[ModelPermission()])
+            for served_model_name in self.served_model_names
         ]
         return ModelList(data=model_cards)
 
@@ -97,7 +98,7 @@ class OpenAIServing:
                              code=status_code.value)
 
     async def _check_model(self, request) -> Optional[ErrorResponse]:
-        if request.model == self.served_model:
+        if request.model in self.served_model_names:
             return
         return self.create_error_response(
             message=f"The model `{request.model}` does not exist.",


### PR DESCRIPTION
This means that you can have more specific model names without requiring users to update their configs whenever you change something that warrants a model name change.

If you passed `--served-model-name gpt-4-0613 gpt-4`, then your users could make requests to either `gpt-4` or `gpt-4-0613`. The `model` field of any responses will contain the first model name, `gpt-4-0613` in this case, so that a user using `gpt-4` knows which version of the model answered their request.

OpenAI calls this [Continuous model upgrades](https://platform.openai.com/docs/models/continuous-model-upgrades).