### PR TITLE
Avoid connection error when vLLM is inside a container without internet access

### DIFF
--- a/vllm/utils.py
+++ b/vllm/utils.py
@@ -163,7 +163,10 @@ def make_async(func: Callable[..., T]) -> Callable[..., Awaitable[T]]:
 
 def get_ip() -> str:
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
-    s.connect(("8.8.8.8", 80))  # Doesn't need to be reachable
+    try:
+        s.connect(("8.8.8.8", 80))  # Doesn't need to be reachable
+    except OSError:
+        pass
     return s.getsockname()[0]
 
 


### PR DESCRIPTION
I observed an `OSError` when trying to run vLLM within a container without internet access. We shouldn't remove the attempt to connect as it might affect the IP that is returned in `getsockname`.